### PR TITLE
Add auto-release milestones from published qm/milestones

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,14 @@
+name: 📦 Release
+on:
+  milestone:
+    types: [closed]
+jobs:
+  release:
+    name: 📝 Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📦 Create draft release from milestone
+        uses: quaternionmedia/milestones@main


### PR DESCRIPTION
# Auto Release
Automatically creates a release draft from closed milestones, using [quaternionmedia/milestones](https://github.com/quaternionmedia/milestones/)

Auto updating by pointing to `@main`