### PR TITLE
Typescript comments

### DIFF
--- a/src/components/components.ts
+++ b/src/components/components.ts
@@ -1,6 +1,18 @@
 import m from 'mithril'
 import { Stream } from '../types'
 
+/**
+  Create an Observable POJO component from a Stream()
+
+  @param {Stream} s the stream to map
+  @returns {Object} a POJO component with a {view}
+
+  This component accepts a Stream(), and returns a component with a view of: `<div>value</div>`
+  It is not rendered to a mithril object. To render to a mithril, use:
+    `m(Observable(stream))`
+  or the shortcut wrapper:
+    `o(stream)`
+*/
 export const Observable = (s: Stream) => {
   return {
     oncreate: ({ dom }) => {
@@ -13,8 +25,25 @@ export const Observable = (s: Stream) => {
   }
 }
 
+/**
+  Observable mithril component
+
+  @param stream: Stream The stream() to observe. See Observable() for detailed usage.
+  @param attrs: attrs The mithril attributes to pass to the component.
+  @returns {m} a mithril object
+
+  This is a mithril component wrapper around the Observable POJO components
+  Use this to view the value of a Stream() which update as the stream updates
+*/
 export const o = (o: Stream, attrs?: any) => m(Observable(o), attrs)
 
+/**
+  Creates a Container Object wrapper to contain child elements
+
+  @param attrs: Object the mithril parameters to pass to this container
+  @param children the children to pass in to the container
+  @returns {Object} a POJO component with a view
+*/
 export const Container = {
   view: ({ attrs, children }) => m('.container', attrs, children),
 }

--- a/src/components/transport.ts
+++ b/src/components/transport.ts
@@ -5,6 +5,12 @@ import './transport.css'
 import { o, Container } from './components'
 import { Button } from 'construct-ui'
 
+export const LABELS = {
+  started: '| |',
+  stopped: '>',
+  paused: '>',
+}
+
 export const Stop = {
   view: ({ attrs }) =>
     m(Button, {
@@ -17,7 +23,7 @@ export const Stop = {
 export const PlayPause = {
   view: ({ attrs: { state } }) =>
     m(Button, {
-      label: o(state().state),
+      label: o(state().state.map(l => LABELS[l])),
       onclick: () => {
         console.log('clicked PlayPause')
         if (state().state() == 'started') {


### PR DESCRIPTION
# Typescript comments
Adds comments to functions to provide typescript definitions to show automatically.

Using `@param` / `@return` with expanded descriptions.