### PR TITLE
Observable streams 🚰

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/mergerino": "^0.4.0",
     "@types/mithril": "^2.0.11",
+    "meiosis-tracer": "^4.0.0",
     "parcel": "^2.6.2"
   },
   "dependencies": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,17 +1,19 @@
 import { Transport } from 'tone'
-import { Cell } from './types'
+import { Cell, TransportState } from './types'
 
 export const Actions = {
   clockTick: (cell: Cell, t: String) => {
     console.log('clockTick', cell, t)
     let bbs = t.split(':')
+    let states: TransportState = cell.getStream()
+    states.bars(Number(bbs[0]))
+    states.beats(Number(bbs[1]))
+    states.sixteenths(Number(bbs[2]))
+    states.bpm(Transport.bpm.value)
+    states.state(Transport.state)
+
     cell.update({
       time: t,
-      bars: Number(bbs[0]),
-      beats: Number(bbs[1]),
-      sixteenths: Number(bbs[2]),
-      bpm: Transport.bpm.value,
-      state: Transport.state,
     })
   },
 }

--- a/src/components/state.ts
+++ b/src/components/state.ts
@@ -5,6 +5,11 @@ import './syntax.css'
 State viewer
 */
 export const State = {
+  oncreate: ({ dom, attrs: { cell } }) => {
+    cell.getStream.map(s => {
+      m.render(dom, m('pre', {}, JSON.stringify(s, null, 2)))
+    })
+  },
   view: ({ attrs: { cell } }) =>
     m('pre', {}, JSON.stringify(cell.state, null, 2)),
 }

--- a/src/components/tracer.ts
+++ b/src/components/tracer.ts
@@ -1,0 +1,9 @@
+import m from 'mithril'
+import meiosisTracer from 'meiosis-tracer'
+
+export const Tracer = {
+  oncreate: ({ attrs: { cells } }) => {
+    meiosisTracer({ selector: '#tracer', streams: [cells] })
+  },
+  view: () => m('#tracer'),
+}

--- a/src/components/transports/clock.ts
+++ b/src/components/transports/clock.ts
@@ -1,13 +1,14 @@
 import m from 'mithril'
 import { o } from '../components'
+import './clock.css'
 
 export const TransportClock = {
   view: ({ attrs: { cell } }) =>
     m('.clock', {}, [
-      cell.state.bars,
+      o(cell.state.bars),
       ':',
-      cell.state.beats,
+      o(cell.state.beats),
       ':',
-      cell.state.sixteenths,
+      o(cell.state.sixteenths),
     ]),
 }

--- a/src/components/transports/clock.ts
+++ b/src/components/transports/clock.ts
@@ -1,14 +1,20 @@
 import m from 'mithril'
 import { o } from '../components'
-import './clock.css'
+import { OneIndex, TwoDecimal } from '../../utils/streams'
+
+export const Digit = {
+  view: ({ attrs, children }) => m('.digit', attrs, children),
+}
+
+export const Seperator = m('.seperator', {}, ':')
 
 export const TransportClock = {
   view: ({ attrs: { cell } }) =>
     m('.clock', {}, [
-      o(cell.state.bars),
-      ':',
-      o(cell.state.beats),
-      ':',
-      o(cell.state.sixteenths),
+      m(Digit, o(OneIndex(cell.state.bars))),
+      Seperator,
+      m(Digit, o(OneIndex(cell.state.beats))),
+      Seperator,
+      m(Digit, o(TwoDecimal(OneIndex(cell.state.sixteenths)))),
     ]),
 }

--- a/src/components/transports/transport.css
+++ b/src/components/transports/transport.css
@@ -5,6 +5,7 @@
 
 .clock {
   display: inline-flex;
+  min-width: 150px;
   border: 3px aqua;
   border-style: outset;
   color: #0f0;
@@ -14,7 +15,7 @@
 }
 
 .clock * {
-  padding-left: 0.5rem;
+  padding-left: 5px;
 }
 
 .container {

--- a/src/components/transports/transport.ts
+++ b/src/components/transports/transport.ts
@@ -2,7 +2,7 @@ import m from 'mithril'
 import { Transport } from 'tone'
 import { TransportClock } from './clock'
 import './transport.css'
-import { Container } from '../components'
+import { o, Container } from '../components'
 import { Button } from 'construct-ui'
 
 export const LABELS = {
@@ -23,10 +23,10 @@ export const Stop = {
 export const PlayPause = {
   view: ({ attrs: { cell } }) =>
     m(Button, {
-      label: cell.state.state,
+      label: o(cell.state.state),
       onclick: () => {
         console.log('clicked PlayPause', cell, cell.state.state)
-        if (cell.state.state == 'started') {
+        if (cell.state.state() == 'started') {
           Transport.pause()
         } else {
           Transport.start()

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,12 +18,9 @@ const initialState: TransportState = {
 export const update = stream()
 export const states = scan(merge, initialState, update)
 export const getState = () => states()
-export const createCell = state => ({ state, getState, update })
+export const getStream = states
+export const createCell = state => ({ state, getState, getStream, update })
 export const cells = states.map(createCell)
-
-cells.map(() => {
-  m.redraw()
-})
 
 window.state = states
 window.cells = cells

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,5 +18,6 @@ export interface TransportState {
 export interface Cell {
   update: Stream
   state: Stream
-  getState: Stream
+  getState: Object
+  getStream: Stream
 }


### PR DESCRIPTION
# Observable streams :potable_water: 
Migrate components to use Observable streams, instead of `m.redraw()`

Progresses #26

### State
- `cell.getStream` to get access to `states` stream
- Include type definition
- Migrates `clockTick` action to directly modify streams
- Migrates `State` viewer to use `getStream`
- Removes `m.redraw()`

### Clock
- uses `o(stream)` to observe digits
- `Digit` component with `.digit` class
- `Seperator` component `.seperator` class
- Re-adds `OneIndex`, `TwoDecimal` stream helpers
- Minor css enhancements

### Tracer
- Adds [meiosis-tracer](https://meiosis.js.org/tracer/index.html) as debug component
  - `devDependencies` only

